### PR TITLE
CI: free-tier guardrails (artifact retention, concurrency, job timeouts)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,9 +9,14 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
     - name: Cache Maven packages


### PR DESCRIPTION
## Summary

Applies free-tier CI cost guardrails to keep GitHub Actions inside the org's free allowance (3,000 min/month, 2 GB storage) after the June 2026 overages. Minimal, upstream-merge-safe additions only — no restructuring of upstream workflow logic.

## Changes

### `.github/workflows/maven.yml` (Java CI with Maven)
- Added a top-level **concurrency** block `group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. Pure CI (no publish/release/deploy), so superseded push/PR runs are cancelled to save minutes.
- Added **`timeout-minutes: 15`** to the `build` job so a hung build cannot burn minutes indefinitely.

No `upload-artifact` steps present (nothing to retention-cap), no deprecated auto-failing action versions (checkout@v4 and cache@v4 already current), and no `schedule:` triggers.

## Flagged cron schedules
None — this workflow has no scheduled triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)