### PR TITLE
Add MC 26.2 support via dedicated 26_2_R1 NMS module

### DIFF
--- a/26_2_R1/pom.xml
+++ b/26_2_R1/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.seanomik</groupId>
+        <artifactId>tamablefoxes-parent</artifactId>
+        <version>2.3.2-FOX</version>
+    </parent>
+
+    <!-- FOX: copy of 26_1_R1 compiled against Spigot 26.2 (the only source change is
+         the CriteriaTriggers import: 26.2 moved it to net.minecraft.advancements.triggers).
+         Same build constraints as 26_1_R1: Mojang-mapped, unversioned craftbukkit, no
+         specialsource remap, JDK 25 build emitting release 21 bytecode. Requires the
+         BuildTools artifact for rev 26.2 in the local repository (see
+         compileSpigotVersions.sh). The vendored anvilgui Wrapper26_R1 lives in the
+         26_1_R1 module only, so it is shaded into the final jar exactly once. -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>21</release>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <artifactId>tamablefoxes_v26_2_R1</artifactId>
+
+    <repositories>
+        <repository>
+            <id>mvn-wesjd-net</id>
+            <url>https://mvn.wesjd.net/</url>
+        </repository>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.seanomik</groupId>
+            <artifactId>tamablefoxes-util</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>26.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.wesjd</groupId>
+            <artifactId>anvilgui</artifactId>
+            <version>1.10.13-SNAPSHOT</version> <!-- FOX: first version with Wrapper26_R1 -->
+        </dependency>
+    </dependencies>
+</project>

--- a/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/EntityTamableFox.java
+++ b/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/EntityTamableFox.java
@@ -1,0 +1,754 @@
+package net.seanomik.tamablefoxes.versions.version_26_2_R1;
+
+import net.minecraft.advancements.triggers.CriteriaTriggers;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.DifficultyInstance;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.*;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.ai.goal.AvoidEntityGoal;
+import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.entity.ai.goal.LeapAtTargetGoal;
+import net.minecraft.world.entity.ai.goal.RandomStrollGoal;
+import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
+import net.minecraft.world.entity.animal.*;
+import net.minecraft.world.entity.animal.chicken.Chicken;
+import net.minecraft.world.entity.animal.equine.AbstractHorse;
+import net.minecraft.world.entity.animal.fish.AbstractFish;
+import net.minecraft.world.entity.animal.fish.AbstractSchoolingFish;
+import net.minecraft.world.entity.animal.fox.Fox;
+import net.minecraft.world.entity.animal.polarbear.PolarBear;
+import net.minecraft.world.entity.animal.rabbit.Rabbit;
+import net.minecraft.world.entity.animal.turtle.Turtle;
+import net.minecraft.world.entity.animal.wolf.Wolf;
+import net.minecraft.world.entity.monster.Creeper;
+import net.minecraft.world.entity.monster.Ghast;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.*;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.ServerLevelAccessor;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.scores.PlayerTeam;
+import net.seanomik.tamablefoxes.util.Utils;
+import net.seanomik.tamablefoxes.util.io.Config;
+import net.seanomik.tamablefoxes.util.io.LanguageConfig;
+import net.seanomik.tamablefoxes.util.io.sqlite.SQLiteHelper;
+import net.seanomik.tamablefoxes.versions.version_26_2_R1.pathfinding.*;
+import net.wesjd.anvilgui.AnvilGUI;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
+import org.bukkit.GameRule;
+import org.bukkit.craftbukkit.event.CraftEventFactory;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+public class EntityTamableFox extends Fox {
+
+    //private static final EntityDataAccessor<Byte> bw; // DATA_FLAGS_ID
+    private static final Predicate<Entity> AVOID_PLAYERS; // AVOID_PLAYERS
+
+    // Rate limiter for the safety-net NPE catches in finalizeSpawn / readAdditionalSaveData.
+    // Logs the first NPE_LOG_LIMIT stack traces in full so we can diagnose the source,
+    // then suppresses further occurrences to avoid spamming the server log.
+    private static final AtomicInteger NPE_LOG_COUNT = new AtomicInteger(0);
+    private static final int NPE_LOG_LIMIT = 5;
+
+    static {
+        AVOID_PLAYERS = (entity) -> !entity.isCrouching();// && EntitySelector.test(entity);
+    }
+
+    private static void logFoxNpeRateLimited(String where, NullPointerException e) {
+        int n = NPE_LOG_COUNT.incrementAndGet();
+        if (n <= NPE_LOG_LIMIT) {
+            Bukkit.getLogger().log(java.util.logging.Level.SEVERE,
+                "[TamableFoxes] NPE in " + where + " (occurrence " + n + "/" + NPE_LOG_LIMIT
+                    + ") — entity will continue loading/spawning. Stack trace follows for diagnosis:", e);
+        } else if (n == NPE_LOG_LIMIT + 1) {
+            Bukkit.getLogger().severe("[TamableFoxes] Further NPEs in fox load/spawn will be suppressed ("
+                + NPE_LOG_LIMIT + " stack traces logged above). Entities continue to load/spawn safely.");
+        }
+    }
+
+    List<Goal> untamedGoals;
+    private FoxPathfinderGoalSitWhenOrdered goalSitWhenOrdered;
+
+    private FoxPathfinderGoalSleepWhenOrdered goalSleepWhenOrdered;
+
+    private boolean tamed;
+
+    public EntityTamableFox(EntityType<? extends Fox> entitytype, Level world) {
+        super(entitytype, world);
+
+        this.getAttribute(Attributes.MOVEMENT_SPEED).setBaseValue(0.33000001192092896D); // Set movement speed
+        if (isTamed()) {
+            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(24.0D);
+            this.getAttribute(Attributes.ATTACK_DAMAGE).setBaseValue(3.0D);
+            this.setHealth(this.getMaxHealth());
+        } else {
+            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(10.0D);
+            this.getAttribute(Attributes.ATTACK_DAMAGE).setBaseValue(2.0D);
+        }
+
+        this.setTamed(false);
+    }
+
+    /**
+     * Factory method to create the land animal target goal.
+     */
+    private NearestAttackableTargetGoal<Animal> createLandTargetGoal() {
+        return new NearestAttackableTargetGoal<>(this, Animal.class, 10, false, false, (entityliving, level) -> {
+            return (!isTamed() || (Config.doesTamedAttackWildAnimals() && isTamed())) && (entityliving instanceof Chicken || entityliving instanceof Rabbit);
+        });
+    }
+
+    /**
+     * Factory method to create the turtle target goal.
+     */
+    private NearestAttackableTargetGoal<Turtle> createTurtleTargetGoal() {
+        return new NearestAttackableTargetGoal<>(this, Turtle.class, 10, false, false, Turtle.BABY_ON_LAND_SELECTOR);
+    }
+
+    /**
+     * Factory method to create the fish target goal.
+     */
+    private NearestAttackableTargetGoal<AbstractFish> createFishTargetGoal() {
+        return new NearestAttackableTargetGoal<>(this, AbstractFish.class, 20, false, false, (entityliving, level) -> {
+            return (!isTamed() || (Config.doesTamedAttackWildAnimals() && isTamed())) && entityliving instanceof AbstractSchoolingFish;
+        });
+    }
+
+    /**
+     * Ensures the Fox superclass target goal fields are initialized.
+     * These fields (landTargetGoal, turtleEggTargetGoal, fishTargetGoal) are normally
+     * set in registerGoals(), but that method only runs when the Level is a ServerLevel.
+     * When foxes are loaded from world data or spawned by plugins, these fields can be
+     * null, causing NPE in Fox.setTargetGoals().
+     *
+     * Why this uses getDeclaredFields() (plural) and not getDeclaredField(String):
+     * the Spigot-mapped 1.21.x modules need the positional scan because Paper's
+     * plugin remapper rewrites getDeclaredField(LITERAL) name strings there. 26.x
+     * has no plugin remapper (this module is Mojang-mapped, see pom.xml), so the
+     * scan is not strictly required here; it is kept so this file stays aligned
+     * with 1_21_R10, and because matching by type instead of by name is immune to
+     * future field renames.
+     */
+    private void ensureTargetGoalFields() {
+        if (populateTargetGoalFieldsByScan()) return;
+        Bukkit.getLogger().severe("[TamableFoxes] Could not initialize Fox target goal fields — fox entities will NPE on load/spawn");
+    }
+
+    /**
+     * Scans Fox.class.getDeclaredFields() for the three Goal-typed fields and
+     * populates any that are null (see ensureTargetGoalFields for why a positional
+     * scan is used instead of field-name lookups).
+     *
+     * Fox declares exactly three Goal-typed fields in this order: landTargetGoal,
+     * turtleEggTargetGoal, fishTargetGoal. No other Goal-typed fields exist on Fox,
+     * so the positional scan is stable across Paper builds for the same Mojang version.
+     */
+    private boolean populateTargetGoalFieldsByScan() {
+        List<Field> goalFields = new ArrayList<>(3);
+        for (Field f : Fox.class.getDeclaredFields()) {
+            if (Goal.class.isAssignableFrom(f.getType())) {
+                f.setAccessible(true);
+                goalFields.add(f);
+                if (goalFields.size() == 3) break;
+            }
+        }
+        if (goalFields.size() < 3) {
+            return false;
+        }
+        try {
+            // Initialize each field independently — never short-circuit on a single
+            // non-null field. registerGoals() can leave a partial state and assuming
+            // "all or nothing" here is what caused Fox.setTargetGoals() to NPE later.
+            if (goalFields.get(0).get(this) == null) {
+                goalFields.get(0).set(this, createLandTargetGoal());
+            }
+            if (goalFields.get(1).get(this) == null) {
+                goalFields.get(1).set(this, createTurtleTargetGoal());
+            }
+            if (goalFields.get(2).get(this) == null) {
+                goalFields.get(2).set(this, createFishTargetGoal());
+            }
+            return true;
+        } catch (ReflectiveOperationException e) {
+            Bukkit.getLogger().warning("[TamableFoxes] Reflection error populating target goal fields by scan: " + e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public void registerGoals() {
+        try {
+            this.goalSitWhenOrdered = new FoxPathfinderGoalSitWhenOrdered(this);
+            this.goalSelector.addGoal(1, goalSitWhenOrdered);
+            this.goalSleepWhenOrdered = new FoxPathfinderGoalSleepWhenOrdered(this);
+            this.goalSelector.addGoal(1, goalSleepWhenOrdered);
+
+            // Populate the Fox superclass target goal fields via the scan-based helper
+            // (see populateTargetGoalFieldsByScan — 26.x has no plugin remapper; the
+            // positional scan is kept for parity with the Spigot-mapped 1.21 modules).
+            populateTargetGoalFieldsByScan();
+
+            this.goalSelector.addGoal(0, getFoxInnerPathfinderGoal("FoxFloatGoal"));
+            this.goalSelector.addGoal(1, getFoxInnerPathfinderGoal("FaceplantGoal"));
+            this.goalSelector.addGoal(2, new FoxPathfinderGoalPanic(this, 2.2D));
+            this.goalSelector.addGoal(2, new FoxPathfinderGoalSleepWithOwner(this));
+            this.goalSelector.addGoal(3, getFoxInnerPathfinderGoal("FoxBreedGoal", Arrays.asList(1.0D), Arrays.asList(double.class)));
+
+            this.goalSelector.addGoal(4, new AvoidEntityGoal<>(this, Player.class, 16.0F, 1.6D, 1.4D, (entityliving) -> {
+                return !isTamed() && AVOID_PLAYERS.test((LivingEntity) entityliving) && !this.isDefending();
+            }));
+            this.goalSelector.addGoal(4, new AvoidEntityGoal<>(this, Wolf.class, 8.0F, 1.6D, 1.4D, (entityliving) -> {
+                return !((Wolf)entityliving).isTame() && !this.isDefending();
+            }));
+            this.goalSelector.addGoal(4, new AvoidEntityGoal<>(this, PolarBear.class, 8.0F, 1.6D, 1.4D, (entityliving) -> {
+                return !this.isDefending();
+            }));
+
+            this.goalSelector.addGoal(5, getFoxInnerPathfinderGoal("StalkPreyGoal"));
+            this.goalSelector.addGoal(6, new FoxPounceGoal());
+            this.goalSelector.addGoal(7, getFoxInnerPathfinderGoal("FoxMeleeAttackGoal", Arrays.asList(1.2000000476837158D, true), Arrays.asList(double.class, boolean.class)));
+            this.goalSelector.addGoal(8, getFoxInnerPathfinderGoal("FoxFollowParentGoal", Arrays.asList(1.25D), Arrays.asList(double.class)));
+            this.goalSelector.addGoal(9, new FoxPathfinderGoalFollowOwner(this, 1.3D, 10.0F, 2.0F, false));
+            this.goalSelector.addGoal(10, new LeapAtTargetGoal(this, 0.4F));
+            this.goalSelector.addGoal(11, new RandomStrollGoal(this, 1.0D));
+            this.goalSelector.addGoal(11, getFoxInnerPathfinderGoal("FoxSearchForItemsGoal"));
+            this.goalSelector.addGoal(12, getFoxInnerPathfinderGoal("FoxLookAtPlayerGoal", Arrays.asList(this, Player.class, 24.0f),
+                        Arrays.asList(Mob.class, Class.class, float.class)));
+
+            this.targetSelector.addGoal(1, new FoxPathfinderGoalOwnerHurtByTarget(this));
+            this.targetSelector.addGoal(2, new FoxPathfinderGoalOwnerHurtTarget(this));
+            this.targetSelector.addGoal(3, (new FoxPathfinderGoalHurtByTarget(this)).setAlertOthers(new Class[0]));
+
+            // Assign all the untamed goals that will later be removed.
+            untamedGoals = new ArrayList<>();
+
+            Goal sleep = getFoxInnerPathfinderGoal("SleepGoal");
+            this.goalSelector.addGoal(7, sleep);
+            untamedGoals.add(sleep);
+
+            Goal perchAndSearch = getFoxInnerPathfinderGoal("PerchAndSearchGoal");
+            this.goalSelector.addGoal(13, perchAndSearch);
+            untamedGoals.add(perchAndSearch);
+
+            Goal eatBerries = new FoxEatBerriesGoal(1.2000000476837158D, 12, 2);
+            this.goalSelector.addGoal(11, eatBerries);
+            untamedGoals.add(eatBerries); // Maybe this should be configurable too?
+
+            Goal seekShelter = getFoxInnerPathfinderGoal("SeekShelterGoal", Arrays.asList(1.25D), Arrays.asList(double.class));
+            this.goalSelector.addGoal(6, seekShelter);
+            untamedGoals.add(seekShelter);
+
+            Goal strollThroughVillage = getFoxInnerPathfinderGoal("FoxStrollThroughVillageGoal", Arrays.asList(32, 200), Arrays.asList(int.class, int.class));
+            this.goalSelector.addGoal(9, strollThroughVillage);
+            untamedGoals.add(strollThroughVillage);
+        } catch (Exception e) {
+            Bukkit.getLogger().severe("[TamableFoxes] Failed to register goals for EntityTamableFox: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    protected EntityDataAccessor<Byte> getDataFlagsId() throws NoSuchFieldException, IllegalAccessException {
+        Field dataFlagsField = Fox.class.getDeclaredField("DATA_FLAGS_ID"); // DATA_FLAGS_ID
+        dataFlagsField.setAccessible(true);
+        EntityDataAccessor<Byte> dataFlagsId = (EntityDataAccessor<Byte>) dataFlagsField.get(null);
+        dataFlagsField.setAccessible(false);
+
+        return dataFlagsId;
+    }
+
+    protected boolean getFlag(int i) {
+        try {
+            EntityDataAccessor<Byte> dataFlagsId = getDataFlagsId();
+
+            return (super.entityData.get(dataFlagsId) & i) != 0;
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+
+        return false;
+    }
+
+    protected void setFlag(int i, boolean flag) {
+        try {
+            EntityDataAccessor<Byte> dataFlagsId = getDataFlagsId();
+
+            if (flag) {
+                this.entityData.set(dataFlagsId, (byte)(this.entityData.get(dataFlagsId) | i));
+            } else {
+                this.entityData.set(dataFlagsId, (byte)(this.entityData.get(dataFlagsId) & ~i));
+            }
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public boolean isDefending() {
+        return getFlag(128);
+    }
+
+    public void setDefending(boolean defending) {
+        setFlag(128, defending);
+    }
+
+    @Override
+    protected void addAdditionalSaveData(ValueOutput valueoutput) {
+        super.addAdditionalSaveData(valueoutput);
+        // FOX: getOwnerUUID() is backed by DATA_TRUSTED_ID_0, which vanilla also
+        // fills for merely *trusting* foxes (e.g. bred babies trust the breeder).
+        // isTamed() already requires a non-zero owner, so persist the owner only for
+        // genuinely tamed foxes; the read path promotes any non-zero ownerUUID to tamed.
+        if (!this.isTamed()) {
+            NMSUtil.putUUID(valueoutput, "ownerUUID", new UUID(0L, 0L));
+        } else {
+            NMSUtil.putUUID(valueoutput, "ownerUUID", this.getOwnerUUID());
+        }
+        // FOX: explicit tamed marker, so the read path never has to infer tamed state
+        // from owner presence for data written by current code.
+        valueoutput.putBoolean("FoxTamed", this.isTamed());
+
+        valueoutput.putBoolean("Sitting", this.goalSitWhenOrdered.isOrderedToSit());
+        valueoutput.putBoolean("Sleeping", this.goalSleepWhenOrdered.isOrderedToSleep());
+    }
+
+    @Override
+    public SpawnGroupData finalizeSpawn(ServerLevelAccessor level, DifficultyInstance difficulty, EntitySpawnReason reason, @Nullable SpawnGroupData spawnGroupData) {
+        ensureTargetGoalFields();
+        try {
+            return super.finalizeSpawn(level, difficulty, reason, spawnGroupData);
+        } catch (NullPointerException e) {
+            // Safety net: if Fox.setTargetGoals() still NPEs despite our field init,
+            // log it but don't propagate the NPE. Otherwise the spawn-egg / spawner /
+            // mob spawning packet handler aborts and the player's action fails.
+            logFoxNpeRateLimited("Fox.finalizeSpawn", e);
+            return spawnGroupData;
+        }
+    }
+
+    @Override
+    protected void readAdditionalSaveData(ValueInput valueinput) {
+        ensureTargetGoalFields();
+        try {
+            super.readAdditionalSaveData(valueinput);
+        } catch (NullPointerException e) {
+            // Safety net: if Fox.setTargetGoals() still NPEs despite our field init
+            // (e.g., due to an unmapped field name), log it but don't crash entity loading.
+            // The fox type, trusted UUIDs, etc. are loaded before setTargetGoals() is called,
+            // so the entity data is still intact.
+            logFoxNpeRateLimited("Fox.readAdditionalSaveData", e);
+        }
+        UUID ownerUuid = null;
+
+        // FOX: addAdditionalSaveData writes "ownerUUID", but this was read back as
+        // "OwnerUUID" (case-sensitive), so tamed state never survived a reload.
+        // Prefer the written key; keep "OwnerUUID" for data saved by the 1.21-1.21.4 modules.
+        String ownerUuidKey = valueinput.getIntArray("ownerUUID").isPresent() ? "ownerUUID" : "OwnerUUID";
+        if (valueinput.getIntArray(ownerUuidKey).isPresent()) {
+            try {
+                ownerUuid = NMSUtil.getUUID(valueinput, ownerUuidKey);
+            } catch (IllegalArgumentException e) {
+                String uuidStr = valueinput.getString(ownerUuidKey).orElse("");
+                if (!uuidStr.isEmpty()) {
+                    ownerUuid = UUID.fromString(uuidStr);
+                } else {
+                    ownerUuid = null;
+                }
+            }
+        }
+
+        // FOX: "FoxTamed" is the explicit tamed marker written by current saves; honor
+        // it whenever present. Legacy saves predate the marker and recorded a non-zero
+        // owner unconditionally — the backing DATA_TRUSTED_ID_0 is also set for wild
+        // foxes that merely *trust* a player — so tamed and trusting are indistinguishable
+        // in that data. Rather than guess, reproduce the behavior of whichever module
+        // wrote it, keyed by which owner key it used:
+        //   - lowercase "ownerUUID": written by the 1.21.5-1.21.11 modules, whose read
+        //     path looked only at uppercase "OwnerUUID", so those foxes loaded UNTAMED.
+        //   - uppercase "OwnerUUID": written by the 1.21-1.21.4 modules, whose read path
+        //     promoted on owner presence, so those foxes loaded TAMED.
+        // New saves always write FoxTamed, so this default only affects legacy data and
+        // the upgrade never newly promotes a wild trusting fox.
+        boolean legacyTamedDefault = ownerUuidKey.equals("OwnerUUID");
+        if (valueinput.getBooleanOr("FoxTamed", legacyTamedDefault)
+                && ownerUuid != null && !ownerUuid.equals(new UUID(0, 0))) {
+            this.setOwnerUUID(ownerUuid);
+            this.setTamed(true);
+        } else {
+            this.setTamed(false);
+        }
+
+        if (this.goalSitWhenOrdered != null) {
+            this.goalSitWhenOrdered.setOrderedToSit(valueinput.getBooleanOr("Sitting", false));
+        }
+
+        if (this.goalSleepWhenOrdered != null) {
+            this.goalSleepWhenOrdered.setOrderedToSleep(valueinput.getBooleanOr("Sleeping", false));
+        }
+
+        if (!this.isTamed()) {
+            if (this.goalSitWhenOrdered != null) {
+                this.goalSitWhenOrdered.setOrderedToSit(false);
+            }
+            if (this.goalSleepWhenOrdered != null) {
+                this.goalSleepWhenOrdered.setOrderedToSleep(false);
+            }
+        }
+    }
+
+    public boolean isTamed() {
+        UUID ownerUuid = getOwnerUUID();
+        return this.tamed && (ownerUuid != null && !ownerUuid.equals(new UUID(0, 0)));
+    }
+
+    public void setTamed(boolean tamed) {
+        this.tamed = tamed;
+        this.reassessTameGoals();
+
+        if (tamed) {
+            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(24.0D);
+            this.getAttribute(Attributes.ATTACK_DAMAGE).setBaseValue(3.0D);
+        } else {
+            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(10.0D);
+            this.getAttribute(Attributes.ATTACK_DAMAGE).setBaseValue(2.0D);
+        }
+        this.setHealth(this.getMaxHealth());
+    }
+
+    // Remove untamed goals if its tamed.
+    private void reassessTameGoals() {
+        if (!isTamed()) return;
+
+        for (Goal untamedGoal : untamedGoals) {
+            this.goalSelector.removeGoal(untamedGoal);
+        }
+    }
+
+    public void rename(org.bukkit.entity.Player player) {
+        // FOX: catch errors
+        try {
+            new AnvilGUI.Builder()
+                    .onClick((slot, stateSnapshot) -> {
+                        String text = stateSnapshot.getText();
+                        if (slot == AnvilGUI.Slot.OUTPUT && !text.isEmpty()) {
+                            org.bukkit.entity.Entity tamableFox = this.getBukkitEntity();
+
+                            // This will auto format the name for config settings.
+                            String foxName = LanguageConfig.getFoxNameFormat(text, player.getDisplayName());
+
+                            tamableFox.setCustomName(foxName);
+                            tamableFox.setCustomNameVisible(true);
+                            if (!LanguageConfig.getTamingChosenPerfect(text).equalsIgnoreCase("disabled")) {
+                                stateSnapshot.getPlayer().sendMessage(Config.getPrefix() + ChatColor.GREEN + LanguageConfig.getTamingChosenPerfect(text));
+                            }
+                        } else if (!LanguageConfig.getTamingChosenPerfect(text).equalsIgnoreCase("disabled")) {
+                            stateSnapshot.getPlayer().sendMessage(Config.getPrefix() + ChatColor.GRAY + "The fox was not named");
+                        }
+
+                        return Arrays.asList(AnvilGUI.ResponseAction.close());
+                    })
+                    .text("Fox name")
+                    .title("Name your new friend!")
+                    .plugin(Utils.getTamableFoxesPlugin())
+                    .open(player);
+        } catch (Throwable throwable) {
+            throwable.printStackTrace();
+        }
+    }
+
+    @Override
+    public InteractionResult mobInteract(Player entityhuman, InteractionHand enumhand) {
+        ItemStack itemstack = entityhuman.getItemInHand(enumhand);
+        Item item = itemstack.getItem();
+
+        if (item instanceof SpawnEggItem) {
+            return super.mobInteract(entityhuman, enumhand);
+        }
+
+        if (this.isTamed()) {
+            // Heal the fox if its health is below the max.
+            if (item.builtInRegistryHolder().is(ItemTags.MEAT) && this.getHealth() < this.getMaxHealth()) {
+                FoodProperties foodProperties = itemstack.getComponents().get(DataComponents.FOOD);
+                if (foodProperties != null) {
+                    // Only remove the item from the player if they're in survival mode.
+                    org.bukkit.entity.Player player = (org.bukkit.entity.Player) entityhuman.getBukkitEntity();
+                    if (player.getGameMode() != GameMode.CREATIVE ) {
+                        itemstack.shrink(1);
+                    }
+
+                    this.heal(foodProperties.nutrition(), EntityRegainHealthEvent.RegainReason.EATING);
+                    return InteractionResult.CONSUME;
+                }
+            }
+
+            if (isOwnedBy(entityhuman) && enumhand == InteractionHand.MAIN_HAND) {
+                // This super method checks if the fox can breed or not.
+                InteractionResult flag = super.mobInteract(entityhuman, enumhand);
+
+                // If the player is not sneaking and the fox cannot breed, then make the fox sit.
+                // @TODO: Do I need to use this.eQ() instead of flag != EnumInteractionResult.SUCCESS?
+                if (!entityhuman.isCrouching() && (flag != InteractionResult.SUCCESS || this.isBaby())) {
+                    // Show the rename menu again when trying to use a nametag on the fox.
+                    if (itemstack.getItem() instanceof NameTagItem) {
+                        org.bukkit.entity.Player player = (org.bukkit.entity.Player) entityhuman.getBukkitEntity();
+                        rename(player);
+                        return InteractionResult.PASS;
+                    }
+
+                    this.goalSleepWhenOrdered.setOrderedToSleep(false);
+                    this.goalSitWhenOrdered.setOrderedToSit(!this.isOrderedToSit());
+                    this.setDeltaMovement(Vec3.ZERO); // FOX - set velocity to zero
+                    return InteractionResult.SUCCESS;
+                } else if (entityhuman.isCrouching()) { // Swap/Put/Take item from fox.
+                    // Ignore buckets since they can be easily duplicated.
+                    if (itemstack.getItem() instanceof BucketItem) {
+                        return InteractionResult.PASS;
+                    }
+
+                    // If the fox has something in its mouth and the player has something in its hand, empty it.
+                    if (this.hasItemInSlot(EquipmentSlot.MAINHAND)) {
+                        getBukkitEntity().getWorld().dropItem(getBukkitEntity().getLocation(), CraftItemStack.asBukkitCopy(this.getItemBySlot(EquipmentSlot.MAINHAND)));
+                        this.setItemSlot(EquipmentSlot.MAINHAND, new ItemStack(Items.AIR), false);
+                    } // Check if the player's hand is empty and if it is, make the fox sleep.
+                      // The reason its here is to make sure that we don't take the item
+                      // from its mouth and make it sleep in a single click.
+                    else if (!entityhuman.hasItemInSlot(EquipmentSlot.MAINHAND)) {
+                        this.goalSitWhenOrdered.setOrderedToSit(false);
+                        this.goalSleepWhenOrdered.setOrderedToSleep(!this.goalSleepWhenOrdered.isOrderedToSleep());
+                        this.setDeltaMovement(Vec3.ZERO); // FOX - set velocity to zero
+                    }
+
+                    // Run this a tick later because the item is removed as soon as it is
+                    // put in the fox's mouth. It must stay on the main thread: it reads the
+                    // player's hand and mutates live ItemStacks/equipment.
+                    Bukkit.getScheduler().runTaskLater(Utils.getTamableFoxesPlugin(), ()-> {
+                        // Put item in mouth
+                        if (entityhuman.hasItemInSlot(EquipmentSlot.MAINHAND)) {
+                            ItemStack c = itemstack.copy();
+                            c.setCount(1);
+
+                            // Only remove the item from the player if they're in survival mode.
+                            org.bukkit.entity.Player player = (org.bukkit.entity.Player) entityhuman.getBukkitEntity();
+                            if (player.getGameMode() != GameMode.CREATIVE) {
+                                itemstack.shrink(1);
+                            }
+
+                            this.setItemSlot(EquipmentSlot.MAINHAND, c, false);
+                        }
+                    }, 1L);
+
+                    return InteractionResult.SUCCESS;
+                }
+            }
+        } else if (item == Items.CHICKEN) {
+            // Check if the player has permissions to tame the fox
+            if (Config.canPlayerTameFox((org.bukkit.entity.Player) entityhuman.getBukkitEntity())) {
+                // Only remove the item from the player if they're in survival mode.
+                org.bukkit.entity.Player player = (org.bukkit.entity.Player) entityhuman.getBukkitEntity();
+                if (player.getGameMode() != GameMode.CREATIVE ) {
+                    itemstack.shrink(1);
+                }
+
+                SQLiteHelper sqLiteHelper = SQLiteHelper.getInstance(Utils.getTamableFoxesPlugin());
+                int maxTameCount = Config.getMaxPlayerFoxTames();
+                if (!((org.bukkit.entity.Player) entityhuman.getBukkitEntity()).hasPermission("tamablefoxes.tame.unlimited") && maxTameCount > 0 && sqLiteHelper.getPlayerFoxAmount(entityhuman.getUUID()) >= maxTameCount) {
+                    if (!LanguageConfig.getFoxDoesntTrust().equalsIgnoreCase("disabled")) {
+                        ((org.bukkit.entity.Player) entityhuman.getBukkitEntity()).sendMessage(Config.getPrefix() + ChatColor.RED + LanguageConfig.getFoxDoesntTrust());
+                    }
+
+                    return InteractionResult.SUCCESS;
+                }
+
+                // 0.33% chance to tame the fox, also check if the called tame entity event is cancelled or not.
+                if (this.getRandom().nextInt(3) == 0 && !CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) {
+                    this.tame(entityhuman);
+
+                    this.navigation.stop();
+                    this.goalSitWhenOrdered.setOrderedToSit(true);
+
+                    if (maxTameCount > 0) {
+                        sqLiteHelper.addPlayerFoxAmount(entityhuman.getUUID(), 1);
+                    }
+
+                    getBukkitEntity().getWorld().spawnParticle(org.bukkit.Particle.HEART, getBukkitEntity().getLocation(), 6, 0.5D, 0.5D, 0.5D);
+
+                    // Give player tamed message.
+                    if (!LanguageConfig.getTamedMessage().equalsIgnoreCase("disabled")) {
+                        ((org.bukkit.entity.Player) entityhuman.getBukkitEntity()).sendMessage(Config.getPrefix() + ChatColor.GREEN + LanguageConfig.getTamedMessage());
+                    }
+
+                    // Let the player choose the new fox's name if its enabled in config.
+                    if (Config.askForNameAfterTaming()) {
+                        if (!LanguageConfig.getTamingAskingName().equalsIgnoreCase("disabled")) {
+                            player.sendMessage(Config.getPrefix() + ChatColor.RED + LanguageConfig.getTamingAskingName());
+                        }
+                        rename(player);
+                    }
+                } else {
+                    getBukkitEntity().getWorld().spawnParticle(org.bukkit.Particle.SMOKE, getBukkitEntity().getLocation(), 10, 0.2D, 0.2D, 0.2D, 0.15D);
+                }
+            }
+
+            return InteractionResult.SUCCESS;
+        }
+
+        return super.mobInteract(entityhuman, enumhand);
+    }
+
+    @Override
+    public EntityTamableFox getBreedOffspring(ServerLevel worldserver, AgeableMob entityageable) {
+        EntityTamableFox entityfox = (EntityTamableFox) EntityTypes.FOX.create(worldserver, EntitySpawnReason.BREEDING);
+        entityfox.setVariant(this.getRandom().nextBoolean() ? this.getVariant() : ((Fox)entityageable).getVariant());
+
+        UUID uuid = this.getOwnerUUID();
+        // FOX: a wild fox can have a trusted (non-null) UUID without being tamed;
+        // only a genuinely tamed parent passes ownership to the offspring.
+        if (uuid != null && this.isTamed()) {
+            entityfox.setOwnerUUID(uuid);
+            entityfox.setTamed(true);
+        }
+
+        return entityfox;
+    }
+
+    @Nullable
+    public UUID getOwnerUUID() {
+        return this.entityData == null ? null : this.entityData.get(DATA_TRUSTED_ID_0).map(EntityReference::getUUID).orElse(null);
+    }
+
+    public void setOwnerUUID(@Nullable UUID ownerUuid) {
+        this.entityData.set(DATA_TRUSTED_ID_0, Optional.ofNullable(ownerUuid == null ? null : EntityReference.of(ownerUuid)));
+    }
+
+    public void tame(Player owner) {
+        this.setTamed(true);
+        this.setOwnerUUID(owner.getUUID());
+
+        // Give the player the taming advancement.
+        if (owner instanceof ServerPlayer) {
+            CriteriaTriggers.TAME_ANIMAL.trigger((ServerPlayer) owner, this);
+        }
+    }
+
+    @Nullable
+    public LivingEntity getOwner() {
+        try {
+            UUID ownerUuid = this.getOwnerUUID();
+            return ownerUuid == null ? null : this.level().getPlayerByUUID(ownerUuid);
+        } catch (IllegalArgumentException var2) {
+            return null;
+        }
+    }
+
+    // Only attack entity if its not attacking owner.
+    @Override
+    public boolean canAttack(LivingEntity entity) {
+        return !this.isOwnedBy(entity) && super.canAttack(entity);
+    }
+
+    public boolean isOwnedBy(LivingEntity entity) {
+        return entity == this.getOwner();
+    }
+
+    /*
+     deobf: wantsToAttack (Copied from EntityWolf)
+     This code being from EntityWolf also means that wolves will want to attack foxes
+     Our life would be so much easier if we could extend both EntityFox and EntityTameableAnimal
+    */
+    public boolean wantsToAttack(LivingEntity entityliving, LivingEntity entityliving1) {
+        if (!(entityliving instanceof Creeper) && !(entityliving instanceof Ghast)) {
+            if (entityliving instanceof EntityTamableFox) {
+                EntityTamableFox entityFox = (EntityTamableFox) entityliving;
+                return !entityFox.isTamed() || entityFox.getOwner() != entityliving1;
+            } else {
+                return (!(entityliving instanceof Player)
+                        || !(entityliving1 instanceof Player) ||
+                        ((Player) entityliving1).canHarmPlayer((Player) entityliving)) && ((!(entityliving instanceof AbstractHorse)
+                        || !((AbstractHorse) entityliving).isTamed()) && (!(entityliving instanceof TamableAnimal)
+                        || !((TamableAnimal) entityliving).isTame()));
+            }
+        } else {
+            return false;
+        }
+    }
+
+    // Set the scoreboard team to the same as the owner if its tamed.
+    @Override
+    public PlayerTeam getTeam() {
+        if (this.isTamed()) {
+            LivingEntity var0 = this.getOwner();
+            if (var0 != null) {
+                return var0.getTeam();
+            }
+        }
+
+        return super.getTeam();
+    }
+
+    // Override considersEntityAsAlly (Entity::r(Entity))
+    // This used to be isAlliedTo(Entity) but that is now final and cannot be overridden. Internally that calls this, which can be
+    // Overridden, so this is probably fine
+    @Override
+    public boolean considersEntityAsAlly(Entity entity) {
+        if (this.isTamed() && Objects.equals(entity.getUUID(), this.getOwnerUUID())) {
+            return true;
+        }
+        return super.considersEntityAsAlly(entity);
+    }
+
+
+    // When the fox dies, show a chat message, and remove the player's stored tamed foxed.
+    @Override
+    public void die(DamageSource damageSource) {
+        if (!this.level().isClientSide() && Boolean.TRUE.equals(
+            this.level().getWorld().getGameRuleValue(
+                GameRule.SHOW_DEATH_MESSAGES)) && this.getOwner() instanceof ServerPlayer) {
+            //this.getOwner().sendMessage(this.getCombatTracker().getDeathMessage(), getOwnerUUID());
+            if(this.getOwner() instanceof ServerPlayer player) {
+                player.sendSystemMessage(this.getCombatTracker().getDeathMessage());
+            }
+        }
+
+        // Remove the amount of foxes the player has tamed if the limit is enabled.
+        if (Config.getMaxPlayerFoxTames() > 0 && this.getOwner() != null) {
+            SQLiteHelper sqliteHelper = SQLiteHelper.getInstance(Utils.getTamableFoxesPlugin());
+            sqliteHelper.removePlayerFoxAmount(this.getOwner().getUUID(), 1);
+        }
+
+        super.die(damageSource);
+    }
+
+
+    private Goal getFoxInnerPathfinderGoal(String innerName, List<Object> args, List<Class<?>> argTypes) {
+        return (Goal) Utils.instantiatePrivateInnerClass(Fox.class, innerName, this, args, argTypes);
+    }
+
+    private Goal getFoxInnerPathfinderGoal(String innerName) {
+        return (Goal) Utils.instantiatePrivateInnerClass(Fox.class, innerName, this, Arrays.asList(), Arrays.asList());
+    }
+
+    public boolean isOrderedToSit() { return this.goalSitWhenOrdered.isOrderedToSit(); }
+
+    public void setOrderedToSit(boolean flag) { this.goalSitWhenOrdered.setOrderedToSit(flag); }
+
+    public boolean isOrderedToSleep() { return this.goalSleepWhenOrdered.isOrderedToSleep(); }
+
+    public void setOrderedToSleep(boolean flag) { this.goalSleepWhenOrdered.setOrderedToSleep(flag); }
+}

--- a/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/NMSInterface_26_2_R1.java
+++ b/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/NMSInterface_26_2_R1.java
@@ -1,0 +1,58 @@
+package net.seanomik.tamablefoxes.versions.version_26_2_R1;
+
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntityTypes;
+import net.minecraft.world.entity.animal.fox.Fox;
+import net.seanomik.tamablefoxes.util.NMSInterface;
+import net.seanomik.tamablefoxes.util.io.Config;
+import net.seanomik.tamablefoxes.util.io.LanguageConfig;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.entity.CraftEntity;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+
+public class NMSInterface_26_2_R1 implements NMSInterface {
+    @Override
+    public void registerCustomFoxEntity() {
+
+        try { // Replace the fox entity
+            Field field = EntityTypes.FOX.getClass().getDeclaredField("factory"); // factory = factory
+            field.setAccessible(true);
+            field.set(EntityTypes.FOX, (EntityType.EntityFactory<Fox>) EntityTamableFox::new);
+            Bukkit.getServer().getConsoleSender().sendMessage(Config.getPrefix() + ChatColor.GREEN + LanguageConfig.getSuccessReplaced());
+        } catch (Exception e) {
+            Bukkit.getServer().getConsoleSender().sendMessage(Config.getPrefix() + ChatColor.RED + LanguageConfig.getFailureReplace());
+            // FOX: rethrow so onLoad() can disable the plugin instead of running
+            // half-enabled with vanilla foxes (commands would ClassCastException).
+            throw new IllegalStateException("Failed to replace the fox entity factory", e);
+        }
+    }
+
+    @Override
+    public void spawnTamableFox(Location loc, FoxType type) {
+        EntityTamableFox tamableFox = (EntityTamableFox) ((CraftEntity) loc.getWorld().spawnEntity(loc, org.bukkit.entity.EntityType.FOX)).getHandle();
+        tamableFox.setVariant((type == FoxType.RED) ? Fox.Variant.RED : Fox.Variant.SNOW);
+    }
+
+    @Override
+    public void changeFoxOwner(org.bukkit.entity.Fox fox, Player newOwner) {
+        EntityTamableFox tamableFox = (EntityTamableFox) ((CraftEntity) fox).getHandle();
+        tamableFox.setOwnerUUID(newOwner.getUniqueId());
+    }
+
+    @Override
+    public UUID getFoxOwner(org.bukkit.entity.Fox fox) {
+        EntityTamableFox tamableFox = (EntityTamableFox) ((CraftEntity) fox).getHandle();
+        return tamableFox.getOwnerUUID();
+    }
+
+    @Override
+    public void renameFox(org.bukkit.entity.Fox fox, Player player) {
+        EntityTamableFox tamableFox = (EntityTamableFox) ((CraftEntity) fox).getHandle();
+        tamableFox.rename(player);
+    }
+}

--- a/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/NMSUtil.java
+++ b/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/NMSUtil.java
@@ -1,0 +1,67 @@
+package net.seanomik.tamablefoxes.versions.version_26_2_R1;
+
+import net.minecraft.core.UUIDUtil;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
+import org.bukkit.event.entity.EntityTargetEvent;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+public class NMSUtil {
+
+    private static final Method SET_MOB_TARGET_METHOD;
+    // FOX: Paper 26.x has setTarget(LivingEntity, TargetReason); the Spigot 26.x jar
+    // this module compiles against only has the 3-arg variant with a trailing
+    // fireEvent boolean. Bind whichever exists so this class initializer can't crash
+    // if the overload set changes. (The plugin itself targets Paper — version
+    // selection uses the Paper-only Bukkit#getMinecraftVersion.)
+    private static final boolean SET_MOB_TARGET_HAS_FIRE_EVENT_ARG;
+
+    static {
+        Method setTarget;
+        boolean hasFireEventArg = false;
+        try {
+            setTarget = Mob.class.getMethod("setTarget", LivingEntity.class, EntityTargetEvent.TargetReason.class);
+        } catch (NoSuchMethodException e) {
+            try {
+                setTarget = Mob.class.getMethod("setTarget", LivingEntity.class, EntityTargetEvent.TargetReason.class, boolean.class);
+                hasFireEventArg = true;
+            } catch (NoSuchMethodException e2) {
+                throw new RuntimeException(e2);
+            }
+        }
+        setTarget.setAccessible(true);
+        SET_MOB_TARGET_METHOD = setTarget;
+        SET_MOB_TARGET_HAS_FIRE_EVENT_ARG = hasFireEventArg;
+    }
+
+    public static void setTarget(Mob mob, LivingEntity livingEntity, EntityTargetEvent.TargetReason reason) {
+        try {
+            if (SET_MOB_TARGET_HAS_FIRE_EVENT_ARG) {
+                SET_MOB_TARGET_METHOD.invoke(mob, livingEntity, reason, true);
+            } else {
+                SET_MOB_TARGET_METHOD.invoke(mob, livingEntity, reason);
+            }
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void putUUID(ValueOutput valueOutput, String key, UUID uuid) {
+        valueOutput.putIntArray(key, UUIDUtil.uuidToIntArray(uuid));
+    }
+
+    public static UUID getUUID(ValueInput valueInput, String key) {
+        int[] result = valueInput.getIntArray(key).orElse(null);
+        if (result == null) return null;
+        return getUUITFromTag(result);
+    }
+
+    public static UUID getUUITFromTag(int[] intArray) {
+        return UUIDUtil.uuidFromIntArray(intArray);
+    }
+}

--- a/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalFollowOwner.java
+++ b/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalFollowOwner.java
@@ -1,0 +1,156 @@
+package net.seanomik.tamablefoxes.versions.version_26_2_R1.pathfinding;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.entity.ai.navigation.FlyingPathNavigation;
+import net.minecraft.world.entity.ai.navigation.GroundPathNavigation;
+import net.minecraft.world.entity.ai.navigation.PathNavigation;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.LeavesBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.pathfinder.PathType;
+import net.minecraft.world.level.pathfinder.WalkNodeEvaluator;
+import net.seanomik.tamablefoxes.versions.version_26_2_R1.EntityTamableFox;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.entity.CraftEntity;
+import org.bukkit.event.entity.EntityTeleportEvent;
+
+import java.util.EnumSet;
+
+public class FoxPathfinderGoalFollowOwner extends Goal {
+    public static final int TELEPORT_WHEN_DISTANCE_IS = 12;
+    private static final int MIN_HORIZONTAL_DISTANCE_FROM_PLAYER_WHEN_TELEPORTING = 2;
+    private static final int MAX_HORIZONTAL_DISTANCE_FROM_PLAYER_WHEN_TELEPORTING = 3;
+    private static final int MAX_VERTICAL_DISTANCE_FROM_PLAYER_WHEN_TELEPORTING = 1;
+    private final EntityTamableFox tamableFox;
+    private LivingEntity owner;
+    private final LevelReader level;
+    private final double speedModifier;
+    private final PathNavigation navigation;
+    private int timeToRecalcPath;
+    private final float stopDistance;
+    private final float startDistance;
+    private float oldWaterCost;
+    private final boolean canFly;
+
+    public FoxPathfinderGoalFollowOwner(EntityTamableFox entityfox, double d0, float f, float f1, boolean flag) {
+        this.tamableFox = entityfox;
+        this.level = entityfox.level();
+        this.speedModifier = d0;
+        this.navigation = entityfox.getNavigation();
+        this.startDistance = f;
+        this.stopDistance = f1;
+        this.canFly = flag;
+        this.setFlags(EnumSet.of(Flag.MOVE, Flag.LOOK));
+        if (!(entityfox.getNavigation() instanceof GroundPathNavigation) && !(entityfox.getNavigation() instanceof FlyingPathNavigation)) {
+            throw new IllegalArgumentException("Unsupported mob type for FoxPathfinderGoalFollowOwner");
+        }
+    }
+
+    public boolean canUse() {
+        LivingEntity entityliving = this.tamableFox.getOwner();
+        if (entityliving == null) {
+            return false;
+        } else if (entityliving.isSpectator()) {
+            return false;
+        } else if (this.tamableFox.isOrderedToSit() || this.tamableFox.isOrderedToSleep()) {
+            return false;
+        } else if (this.tamableFox.distanceToSqr(entityliving) < (double)(this.startDistance * this.startDistance)) {
+            return false;
+        } else {
+            this.owner = entityliving;
+            return true;
+        }
+    }
+
+    public boolean canContinueToUse() {
+        return !this.navigation.isDone() && (!this.tamableFox.isOrderedToSit() && !this.tamableFox.isOrderedToSleep() && this.tamableFox.distanceToSqr(this.owner) > (double) (this.stopDistance * this.stopDistance));
+    }
+
+    public void start() {
+        this.timeToRecalcPath = 0;
+        this.oldWaterCost = this.tamableFox.getPathfindingMalus(PathType.WATER);
+        this.tamableFox.setPathfindingMalus(PathType.WATER, 0.0F);
+    }
+
+    public void stop() {
+        this.owner = null;
+        this.navigation.stop();
+        this.tamableFox.setPathfindingMalus(PathType.WATER, this.oldWaterCost);
+    }
+
+    public void tick() {
+        this.tamableFox.getLookControl().setLookAt(this.owner, 10.0F, (float)this.tamableFox.getMaxHeadXRot());
+        if (--this.timeToRecalcPath <= 0) {
+            this.timeToRecalcPath = 10;
+            if (!this.tamableFox.isLeashed() && !this.tamableFox.isPassenger()) {
+                if (this.tamableFox.distanceToSqr(this.owner) >= 144.0D) {
+                    this.teleportToOwner();
+                } else {
+                    this.navigation.moveTo(this.owner, this.speedModifier);
+                }
+            }
+        }
+
+    }
+
+    private void teleportToOwner() {
+        BlockPos blockposition = this.owner.blockPosition();
+
+        for(int i = 0; i < 10; ++i) {
+            int j = this.randomIntInclusive(-3, 3);
+            int k = this.randomIntInclusive(-1, 1);
+            int l = this.randomIntInclusive(-3, 3);
+            boolean flag = this.maybeTeleportTo(blockposition.getX() + j, blockposition.getY() + k, blockposition.getZ() + l);
+            if (flag) {
+                return;
+            }
+        }
+
+    }
+
+    private boolean maybeTeleportTo(int i, int j, int k) {
+        if (Math.abs((double)i - this.owner.getX()) < 2.0D && Math.abs((double)k - this.owner.getZ()) < 2.0D) {
+            return false;
+        } else if (!this.canTeleportTo(new BlockPos(i, j, k))) {
+            return false;
+        } else {
+            CraftEntity entity = this.tamableFox.getBukkitEntity();
+            Location to = new Location(entity.getWorld(), (double)i + 0.5D, (double)j, (double)k + 0.5D, this.tamableFox.getYRot(), this.tamableFox.getXRot());
+            EntityTeleportEvent event = new EntityTeleportEvent(entity, entity.getLocation(), to);
+            this.tamableFox.level().getCraftServer().getPluginManager().callEvent(event);
+            if (event.isCancelled()) {
+                return false;
+            } else {
+                to = event.getTo();
+                this.tamableFox.setPosRaw(to.getX(), to.getY(), to.getZ());
+                this.tamableFox.setYRot(to.getYaw());
+                this.tamableFox.setXRot(to.getPitch());
+                this.tamableFox.setOldPosAndRot();
+                this.tamableFox.setPos(this.tamableFox.position().x, this.tamableFox.position().y, this.tamableFox.position().z);
+                this.navigation.stop();
+                return true;
+            }
+        }
+    }
+
+    private boolean canTeleportTo(BlockPos blockposition) {
+        PathType pathtype = WalkNodeEvaluator.getPathTypeStatic(this.tamableFox, blockposition.mutable());
+        if (pathtype != PathType.WALKABLE) {
+            return false;
+        } else {
+            BlockState iblockdata = this.level.getBlockState(blockposition.below());
+            if (!this.canFly && iblockdata.getBlock() instanceof LeavesBlock) {
+                return false;
+            } else {
+                BlockPos blockposition1 = blockposition.subtract(this.tamableFox.blockPosition());
+                return this.level.noCollision(this.tamableFox, this.tamableFox.getBoundingBox().move(blockposition1));
+            }
+        }
+    }
+
+    private int randomIntInclusive(int i, int j) {
+        return this.tamableFox.getRandom().nextInt(j - i + 1) + i;
+    }
+}

--- a/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalHurtByTarget.java
+++ b/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalHurtByTarget.java
@@ -1,0 +1,123 @@
+package net.seanomik.tamablefoxes.versions.version_26_2_R1.pathfinding;
+
+import net.minecraft.world.entity.*;
+import net.minecraft.world.entity.ai.goal.target.TargetGoal;
+import net.minecraft.world.entity.ai.targeting.TargetingConditions;
+import net.minecraft.world.phys.AABB;
+import net.seanomik.tamablefoxes.versions.version_26_2_R1.EntityTamableFox;
+import net.seanomik.tamablefoxes.versions.version_26_2_R1.NMSUtil;
+import org.bukkit.GameRule;
+import org.bukkit.event.entity.EntityTargetEvent.TargetReason;
+
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+
+public class FoxPathfinderGoalHurtByTarget extends TargetGoal {
+
+    private static final TargetingConditions HURT_BY_TARGETING = TargetingConditions.forCombat().ignoreLineOfSight().ignoreInvisibilityTesting();
+    private static final int ALERT_RANGE_Y = 10;
+    private boolean alertSameType;
+    private int timestamp;
+    private final Class<?>[] toIgnoreDamage;
+    private Class<?>[] toIgnoreAlert;
+
+    public FoxPathfinderGoalHurtByTarget(PathfinderMob entitycreature, Class<?>... aclass) {
+        super(entitycreature, true);
+        this.toIgnoreDamage = aclass;
+        this.setFlags(EnumSet.of(Flag.TARGET));
+    }
+
+    public boolean canUse() {
+        int i = this.mob.getLastHurtByMobTimestamp();
+        LivingEntity entityliving = this.mob.getLastHurtByMob();
+        if (i != this.timestamp && entityliving != null) {
+            if (entityliving.getType() == EntityTypes.PLAYER && Boolean.TRUE.equals(
+                this.mob.level().getWorld().getGameRuleValue(
+                    GameRule.UNIVERSAL_ANGER))) {
+                return false;
+            } else {
+                Class[] aclass = this.toIgnoreDamage;
+                int j = aclass.length;
+
+                for(int k = 0; k < j; ++k) {
+                    Class<?> oclass = aclass[k];
+                    if (oclass.isAssignableFrom(entityliving.getClass())) {
+                        return false;
+                    }
+                }
+
+                return this.canAttack(entityliving, HURT_BY_TARGETING);
+            }
+        } else {
+            return false;
+        }
+    }
+
+    public FoxPathfinderGoalHurtByTarget setAlertOthers(Class<?>... aclass) {
+        this.alertSameType = true;
+        this.toIgnoreAlert = aclass;
+        return this;
+    }
+
+    public void start() {
+        NMSUtil.setTarget(this.mob, this.mob.getLastHurtByMob(), TargetReason.TARGET_ATTACKED_ENTITY);
+        this.targetMob = this.mob.getTarget();
+        this.timestamp = this.mob.getLastHurtByMobTimestamp();
+        this.unseenMemoryTicks = 300;
+        if (this.alertSameType) {
+            this.alertOthers();
+        }
+
+        super.start();
+    }
+
+    protected void alertOthers() {
+        double d0 = this.getFollowDistance();
+        AABB axisalignedbb = AABB.unitCubeFromLowerCorner(this.mob.position()).inflate(d0, 10.0D, d0);
+        List<? extends Mob> list = this.mob.level().getEntitiesOfClass(this.mob.getClass(), axisalignedbb, EntitySelector.NO_SPECTATORS);
+        Iterator iterator = list.iterator();
+
+        while(true) {
+            Mob entityinsentient;
+            boolean flag;
+            do {
+                do {
+                    do {
+                        do {
+                            do {
+                                if (!iterator.hasNext()) {
+                                    return;
+                                }
+
+                                entityinsentient = (Mob)iterator.next();
+                            } while(this.mob == entityinsentient);
+                        } while(entityinsentient.getTarget() != null);
+                    } while(this.mob instanceof EntityTamableFox && ((EntityTamableFox)this.mob).getOwner() != ((EntityTamableFox)entityinsentient).getOwner());
+                } while(entityinsentient.isAlliedTo(this.mob.getLastHurtByMob()));
+
+                if (this.toIgnoreAlert == null) {
+                    break;
+                }
+
+                flag = false;
+                Class[] aclass = this.toIgnoreAlert;
+                int i = aclass.length;
+
+                for(int j = 0; j < i; ++j) {
+                    Class<?> oclass = aclass[j];
+                    if (entityinsentient.getClass() == oclass) {
+                        flag = true;
+                        break;
+                    }
+                }
+            } while(flag);
+
+            this.alertOther(entityinsentient, this.mob.getLastHurtByMob());
+        }
+    }
+
+    protected void alertOther(Mob entityinsentient, LivingEntity entityliving) {
+        NMSUtil.setTarget(entityinsentient, entityliving, TargetReason.TARGET_ATTACKED_NEARBY_ENTITY);
+    }
+}

--- a/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalOwnerHurtByTarget.java
+++ b/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalOwnerHurtByTarget.java
@@ -1,0 +1,56 @@
+package net.seanomik.tamablefoxes.versions.version_26_2_R1.pathfinding;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.goal.target.TargetGoal;
+import net.minecraft.world.entity.ai.targeting.TargetingConditions;
+import net.seanomik.tamablefoxes.versions.version_26_2_R1.EntityTamableFox;
+import net.seanomik.tamablefoxes.versions.version_26_2_R1.NMSUtil;
+import org.bukkit.event.entity.EntityTargetEvent.TargetReason;
+
+import java.util.EnumSet;
+
+public class FoxPathfinderGoalOwnerHurtByTarget extends TargetGoal {
+    private final EntityTamableFox tameAnimal;
+    private LivingEntity ownerLastHurtBy;
+    private int timestamp;
+
+    public FoxPathfinderGoalOwnerHurtByTarget(EntityTamableFox entitytameableanimal) {
+        super(entitytameableanimal, false);
+        this.tameAnimal = entitytameableanimal;
+        this.setFlags(EnumSet.of(Flag.TARGET));
+    }
+
+    public boolean canUse() {
+        if (this.tameAnimal.isTamed() && !this.tameAnimal.isOrderedToSit() && !this.tameAnimal.isOrderedToSleep()) {
+            LivingEntity entityliving = this.tameAnimal.getOwner();
+            if (entityliving == null) {
+                return false;
+            } else {
+                this.ownerLastHurtBy = entityliving.getLastHurtByMob();
+                int i = entityliving.getLastHurtByMobTimestamp();
+                return i != this.timestamp && this.canAttack(this.ownerLastHurtBy, TargetingConditions.DEFAULT) && this.tameAnimal.wantsToAttack(this.ownerLastHurtBy, entityliving);
+            }
+        } else {
+            return false;
+        }
+    }
+
+    public void start() {
+        NMSUtil.setTarget(this.mob, this.ownerLastHurtBy, TargetReason.TARGET_ATTACKED_OWNER);
+        LivingEntity entityliving = this.tameAnimal.getOwner();
+        if (entityliving != null) {
+            this.timestamp = entityliving.getLastHurtByMobTimestamp();
+        }
+
+        tameAnimal.setDefending(false);
+
+        super.start();
+    }
+
+    @Override
+    public void stop() {
+        tameAnimal.setDefending(false);
+
+        super.stop();
+    }
+}

--- a/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalOwnerHurtTarget.java
+++ b/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalOwnerHurtTarget.java
@@ -1,0 +1,57 @@
+package net.seanomik.tamablefoxes.versions.version_26_2_R1.pathfinding;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.goal.target.TargetGoal;
+import net.minecraft.world.entity.ai.targeting.TargetingConditions;
+import net.seanomik.tamablefoxes.versions.version_26_2_R1.EntityTamableFox;
+import net.seanomik.tamablefoxes.versions.version_26_2_R1.NMSUtil;
+import org.bukkit.event.entity.EntityTargetEvent.TargetReason;
+
+import java.util.EnumSet;
+
+public class FoxPathfinderGoalOwnerHurtTarget extends TargetGoal {
+    private final EntityTamableFox tameAnimal;
+    private LivingEntity ownerLastHurt;
+    private int timestamp;
+
+    public FoxPathfinderGoalOwnerHurtTarget(EntityTamableFox entitytameableanimal) {
+        super(entitytameableanimal, false);
+        this.tameAnimal = entitytameableanimal;
+        this.setFlags(EnumSet.of(Flag.TARGET));
+    }
+
+    public boolean canUse() {
+        if (this.tameAnimal.isTamed() && !this.tameAnimal.isOrderedToSit() && !this.tameAnimal.isOrderedToSleep()) {
+            LivingEntity entityliving = this.tameAnimal.getOwner();
+            if (entityliving == null) {
+                return false;
+            } else {
+                this.ownerLastHurt = entityliving.getLastHurtMob();
+                int i = entityliving.getLastHurtMobTimestamp();
+                return i != this.timestamp && this.canAttack(this.ownerLastHurt, TargetingConditions.DEFAULT) && this.tameAnimal.wantsToAttack(this.ownerLastHurt, entityliving);
+            }
+        } else {
+            return false;
+        }
+    }
+
+    public void start() {
+        NMSUtil.setTarget(this.mob, this.ownerLastHurt, TargetReason.OWNER_ATTACKED_TARGET);
+        LivingEntity entityliving = this.tameAnimal.getOwner();
+        if (entityliving != null) {
+            this.timestamp = entityliving.getLastHurtMobTimestamp();
+        }
+
+        tameAnimal.setDefending(true);
+
+        super.start();
+    }
+
+
+    @Override
+    public void stop() {
+        tameAnimal.setDefending(false);
+
+        super.stop();
+    }
+}

--- a/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalPanic.java
+++ b/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalPanic.java
@@ -1,0 +1,21 @@
+package net.seanomik.tamablefoxes.versions.version_26_2_R1.pathfinding;
+
+import net.minecraft.world.entity.ai.goal.PanicGoal;
+import net.seanomik.tamablefoxes.versions.version_26_2_R1.EntityTamableFox;
+
+public class FoxPathfinderGoalPanic extends PanicGoal {
+    EntityTamableFox tamableFox;
+
+    public FoxPathfinderGoalPanic(EntityTamableFox tamableFox, double d0) {
+        super(tamableFox, d0);
+        this.tamableFox = tamableFox;
+    }
+
+    public boolean canUse() {
+        if (tamableFox.isTamed()) {
+            return tamableFox.getHealth() < 2.0f && super.canUse();
+        }
+
+        return tamableFox.isDefending() && super.canUse();
+    }
+}

--- a/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalSitWhenOrdered.java
+++ b/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalSitWhenOrdered.java
@@ -1,0 +1,57 @@
+package net.seanomik.tamablefoxes.versions.version_26_2_R1.pathfinding;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.level.block.Blocks;
+import net.seanomik.tamablefoxes.util.Utils;
+import net.seanomik.tamablefoxes.versions.version_26_2_R1.EntityTamableFox;
+import org.bukkit.Bukkit;
+
+import java.util.EnumSet;
+
+public class FoxPathfinderGoalSitWhenOrdered extends Goal {
+    private final EntityTamableFox mob;
+    private boolean orderedToSit;
+
+    public FoxPathfinderGoalSitWhenOrdered(EntityTamableFox entitytameableanimal) {
+        this.mob = entitytameableanimal;
+        this.setFlags(EnumSet.of(Flag.JUMP, Flag.MOVE));
+    }
+
+    public boolean canContinueToUse() {
+        return this.orderedToSit;
+    }
+
+    public boolean canUse() {
+        if (!this.mob.isTamed()) {
+            return this.orderedToSit && this.mob.getTarget() == null;
+        } else if (this.mob.isInWater() || this.mob.getInBlockState().is(Blocks.BUBBLE_COLUMN)) {
+            return false;
+        } else if (this.mob.isFallFlying()) {
+            return false;
+        } else {
+            LivingEntity entityliving = this.mob.getOwner();
+            return entityliving == null || ((!(this.mob.distanceToSqr(entityliving) < 144.0D) || entityliving.getLastHurtByMob() == null) && this.mob.isOrderedToSit());
+        }
+    }
+
+    public void start() {
+        // For some reason it needs to be ran later to not have the fox slide across the floor.
+        Bukkit.getScheduler().runTaskLater(Utils.getTamableFoxesPlugin(), () -> {
+            this.mob.getNavigation().stop();
+            this.mob.setSitting(true);
+            this.orderedToSit = true;
+        }, 1L);
+    }
+
+    public void stop() {
+        this.mob.setSitting(false);
+        this.orderedToSit = false;
+    }
+
+    public boolean isOrderedToSit() { return this.orderedToSit; }
+
+    public void setOrderedToSit(boolean flag) {
+        this.orderedToSit = flag;
+    }
+}

--- a/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalSleepWhenOrdered.java
+++ b/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalSleepWhenOrdered.java
@@ -1,0 +1,52 @@
+package net.seanomik.tamablefoxes.versions.version_26_2_R1.pathfinding;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.level.block.Blocks;
+import net.seanomik.tamablefoxes.versions.version_26_2_R1.EntityTamableFox;
+
+import java.util.EnumSet;
+
+public class FoxPathfinderGoalSleepWhenOrdered extends Goal {
+    private final EntityTamableFox mob;
+    private boolean orderedToSleep;
+
+    public FoxPathfinderGoalSleepWhenOrdered(EntityTamableFox entitytameableanimal) {
+        this.mob = entitytameableanimal;
+        this.setFlags(EnumSet.of(Flag.JUMP, Flag.MOVE));
+    }
+
+    public boolean canContinueToUse() {
+        return this.orderedToSleep;
+    }
+
+    public boolean canUse() {
+        if (!this.mob.isTamed()) {
+            return this.orderedToSleep && this.mob.getTarget() == null;
+        } else if (this.mob.isInWater() || this.mob.getInBlockState().is(Blocks.BUBBLE_COLUMN)) {
+            return false;
+        } else if (this.mob.isFallFlying()) {
+            return false;
+        } else {
+            LivingEntity entityliving = this.mob.getOwner();
+            return entityliving == null || ((!(this.mob.distanceToSqr(entityliving) < 144.0D) || entityliving.getLastHurtByMob() == null) && this.mob.isOrderedToSleep());
+        }
+    }
+
+    public void start() {
+        this.mob.getNavigation().stop();
+        this.mob.setSleeping(true);
+        this.orderedToSleep = true;
+    }
+
+    public void stop() {
+        this.mob.setSleeping(false);
+        this.orderedToSleep = false;
+    }
+
+    public boolean isOrderedToSleep() { return this.orderedToSleep; }
+
+    public void setOrderedToSleep(boolean flag) {
+        this.orderedToSleep = flag;
+    }
+}

--- a/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalSleepWithOwner.java
+++ b/26_2_R1/src/main/java/net/seanomik/tamablefoxes/versions/version_26_2_R1/pathfinding/FoxPathfinderGoalSleepWithOwner.java
@@ -1,0 +1,112 @@
+package net.seanomik.tamablefoxes.versions.version_26_2_R1.pathfinding;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.BedBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.seanomik.tamablefoxes.versions.version_26_2_R1.EntityTamableFox;
+
+import java.util.Iterator;
+import java.util.List;
+
+// From class EntityCat#b
+public class FoxPathfinderGoalSleepWithOwner extends Goal {
+    private final EntityTamableFox fox;
+    private Player ownerPlayer;
+    private BlockPos goalPos;
+    private int onBedTicks;
+
+    public FoxPathfinderGoalSleepWithOwner(EntityTamableFox entityTamableFox) {
+        this.fox = entityTamableFox;
+    }
+
+    public boolean canUse() {
+        if (!this.fox.isTamed()) {
+            return false;
+        } else if (this.fox.isOrderedToSleep()) {
+            return false;
+        } else {
+            LivingEntity entityliving = this.fox.getOwner();
+            if (entityliving instanceof Player) {
+                this.ownerPlayer = (Player)entityliving;
+                if (!entityliving.isSleeping()) {
+                    return false;
+                }
+
+                if (this.fox.distanceToSqr(this.ownerPlayer) > 100.0D) {
+                    return false;
+                }
+
+                BlockPos blockposition = this.ownerPlayer.blockPosition();
+                BlockState iblockdata = this.fox.level().getBlockState(blockposition);
+                if (iblockdata.is(BlockTags.BEDS)) {
+                    this.goalPos = (BlockPos)iblockdata.getOptionalValue(BedBlock.FACING).map((enumdirection) -> {
+                        return blockposition.relative(enumdirection.getOpposite());
+                    }).orElseGet(() -> {
+                        return new BlockPos(blockposition);
+                    });
+                    return !this.spaceIsOccupied();
+                }
+            }
+
+            return false;
+        }
+    }
+
+    private boolean spaceIsOccupied() {
+        List<EntityTamableFox> list = this.fox.level().getEntitiesOfClass(EntityTamableFox.class, (new AABB(this.goalPos)).inflate(2.0D));
+        Iterator iterator = list.iterator();
+
+        EntityTamableFox entityTamableFox;
+        do {
+            do {
+                if (!iterator.hasNext()) {
+                    return false;
+                }
+
+                entityTamableFox = (EntityTamableFox)iterator.next();
+            } while(entityTamableFox == this.fox);
+        } while(!entityTamableFox.isSleeping());// && !entityTamableFox.isRelaxStateOne());
+
+        return true;
+    }
+
+    public boolean canContinueToUse() {
+        return this.fox.isTamed() && !this.fox.isOrderedToSleep() && this.ownerPlayer != null && this.ownerPlayer.isSleeping() && this.goalPos != null && !this.spaceIsOccupied();
+    }
+
+    public void start() {
+        if (this.goalPos != null) {
+            this.fox.setSitting(false);
+            this.fox.getNavigation().moveTo((double)this.goalPos.getX(), (double)this.goalPos.getY(), (double)this.goalPos.getZ(), 1.100000023841858D);
+        }
+
+    }
+
+    public void stop() {
+        this.fox.setSleeping(false);
+        this.onBedTicks = 0;
+        this.fox.getNavigation().stop();
+    }
+
+    public void tick() {
+        if (this.ownerPlayer != null && this.goalPos != null) {
+            this.fox.setSitting(false);
+            this.fox.getNavigation().moveTo((double)this.goalPos.getX(), (double)this.goalPos.getY(), (double)this.goalPos.getZ(), 1.100000023841858D);
+            if (this.fox.distanceToSqr(this.ownerPlayer) < 2.5D) {
+                ++this.onBedTicks;
+                if (this.onBedTicks > 16) {
+                    this.fox.setSleeping(true);
+                } else {
+                    this.fox.lookAt(this.ownerPlayer, 45.0F, 45.0F);
+                }
+            } else {
+                this.fox.setSleeping(false);
+            }
+        }
+    }
+}

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -21,6 +21,24 @@
     </properties>
 
     <build>
+        <!-- FOX: expand ${project.version} in plugin.yml; without filtering the token
+             ships verbatim and the server logs "Tamablefoxes v${project.version}". -->
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>plugin.yml</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>plugin.yml</exclude>
+                </excludes>
+            </resource>
+        </resources>
         <plugins>
             <!-- Shade plugin configuration inchangée -->
             <plugin>
@@ -259,6 +277,12 @@
         <dependency>
             <groupId>net.seanomik</groupId>
             <artifactId>tamablefoxes_v26_1_R1</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.seanomik</groupId>
+            <artifactId>tamablefoxes_v26_2_R1</artifactId>
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/Plugin/src/main/java/net/seanomik/tamablefoxes/TamableFoxes.java
+++ b/Plugin/src/main/java/net/seanomik/tamablefoxes/TamableFoxes.java
@@ -82,17 +82,19 @@ public final class TamableFoxes extends JavaPlugin implements Listener {
             case "1.21.11" -> nmsInterface = new NMSInterface_1_21_11_R1();
 
             // FOX: Paper/Spigot 26.x are Mojang-mapped with an unversioned craftbukkit
-            // package, so the whole 26.1.x patch family (shared 26_1_R1 NMS revision)
+            // package, so each 26.x patch family (shared NMS revision: 26_1_R1, 26_2_R1)
             // uses its own (non-remapped) module. Routing by prefix instead of a single
-            // pinned string means a routine Paper patch bump (26.1.3, ...) doesn't
-            // disable foxes on a version it's actually compatible with. The module is
-            // loaded via reflection so older servers never resolve its classes; if a
+            // pinned string means a routine Paper patch bump (26.1.3, 26.2.1, ...) doesn't
+            // disable foxes on a version it's actually compatible with. The modules are
+            // loaded via reflection so other servers never resolve their classes; if a
             // future patch ever changes the mapping, registration throws and the loader
             // fails safe to the same "unsupported version" disable as the default below.
             default -> {
                 String mcVersion = Bukkit.getMinecraftVersion();
                 if (mcVersion.equals("26.1") || mcVersion.startsWith("26.1.")) {
                     nmsInterface = loadNMSInterfaceByName("net.seanomik.tamablefoxes.versions.version_26_1_R1.NMSInterface_26_1_R1");
+                } else if (mcVersion.equals("26.2") || mcVersion.startsWith("26.2.")) {
+                    nmsInterface = loadNMSInterfaceByName("net.seanomik.tamablefoxes.versions.version_26_2_R1.NMSInterface_26_2_R1");
                 } else {
                     abortLoad(LanguageConfig.getUnsupportedMCVersionRegister(),
                             "You're trying to run MC version " + mcVersion + " which is not supported!");

--- a/Plugin/src/main/resources/language.yml
+++ b/Plugin/src/main/resources/language.yml
@@ -1,6 +1,6 @@
 mc-version-loading: "Registering entity for MC Version %MC_VERSION%..."
-unsupported-mc-version-not-registering: "ERROR: This plugin version only supports Spigot 1.14-1.18.1! Not registering entity!"
-unsupported-mc-version-disabling: "This plugin version only supports Spigot 1.14-1.18.1! Disabling plugin!"
+unsupported-mc-version-not-registering: "ERROR: This plugin version does not support this server version! Not registering entity!"
+unsupported-mc-version-disabling: "This plugin version does not support this server version! Disabling plugin!"
 success-replaced-entity: "Replaced tamable fox entity!"
 error-to-replaced-entity: "Failed to replace tamable fox entity!"
 saving-foxes-message: "Saving foxes."

--- a/compileSpigotVersions.sh
+++ b/compileSpigotVersions.sh
@@ -24,3 +24,4 @@ java -jar ./BuildTools.jar --rev 1.20.4 --remapped --compile-if-changed
 
 # Java 25 (26.x is Mojang-mapped, no --remapped classifiers anymore)
 java -jar ./BuildTools.jar --rev 26.1.2 --compile-if-changed
+java -jar ./BuildTools.jar --rev 26.2 --compile-if-changed

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>1_21_R10</module>
 
         <module>26_1_R1</module>
+        <module>26_2_R1</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary
On 26.2 `Bukkit.getMinecraftVersion()` returns `"26.2"`, which fell through the version switch to the unsupported-version disable path (with the stale "only supports Spigot 1.14-1.18.1" message from `language.yml`). 26.1.2 worked because #5 added the `26_1_R1` module with `26.1`-prefix routing; nothing routed `26.2`.

- **New `26_2_R1` module** — copy of `26_1_R1` compiled against `org.spigotmc:spigot:26.2-R0.1-SNAPSHOT` (BuildTools now has rev 26.2). Source drift beyond the package rename is exactly the two real 26.2 NMS changes:
  - the static entity type constants moved from `EntityType` to the new `EntityTypes` class (`EntityTypes.FOX` for the factory swap and breeding, `EntityTypes.PLAYER` in `FoxPathfinderGoalHurtByTarget`);
  - `CriteriaTriggers` moved to `net.minecraft.advancements.triggers`.

  Everything else the module touches was verified unchanged between the 26.1.2 and 26.2 server jars by `javap` diff: `EntityType.factory` field + `EntityFactory.create` dispatch, `Fox` ctor/overridden methods/`DATA_FLAGS_ID`/`DATA_TRUSTED_ID_0`/the three Goal-typed target fields (positional scan) and all inner-goal constructor signatures, `ValueInput`/`ValueOutput`, `EntityReference`, `Mob#setTarget` overloads, and the unversioned craftbukkit classes. The vendored AnvilGUI `Wrapper26_R1` stays in `26_1_R1` only (shaded once); AnvilGUI's `VersionMatcher` falls back to revision `26_R1` on unversioned craftbukkit, and its full link surface is unchanged on 26.2.
- **Routing** — `26.2`/`26.2.x` prefix-routes to `NMSInterface_26_2_R1` via the existing reflective loader (same fail-safe as 26.1: a load/registration failure disables the plugin instead of half-enabling).
- **plugin.yml version** — enabled maven resource filtering for `plugin.yml` only; the jar previously logged `Tamablefoxes v${project.version}`. Now: `version: 2.3.2-FOX`.
- **Stale message** — the `language.yml` unsupported-version defaults no longer claim "only supports Spigot 1.14-1.18.1".
- `compileSpigotVersions.sh` gains `--rev 26.2`.

## Testing
- Full reactor build with maven 3.9.6 under JDK 25: `BUILD SUCCESS`, all 28 modules, against genuine BuildTools artifacts (ran BuildTools rev 26.2, 26.1.2 and 1.21.11-remapped locally to populate `~/.m2`).
- `26_2_R1` sources additionally compile cleanly with javac against the actual UniverseSpigot 26.2 runtime jar from the test server (`universe-26.2.jar` + its `libraries/`), so every reference resolves against the exact server flavor that failed.
- Shaded jar verified: `version_26_2_R1` classes present at class-file 65 (Java 21, safe for Paper ≤1.21.4's remapper), single `Wrapper26_R1` entry, `plugin.yml` expanded.
- No runtime test on a live 26.2 server (not started per ops policy). Version-string handling is prefix-based, so both `26.2` (Universe reports MC version `26.2`, Bukkit version `26.2.build.1-stable`) and `26.2-R0.1-SNAPSHOT` flavors route identically.

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfv5s63SGCep1rxso5hWEy